### PR TITLE
Added node template creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,17 @@ terraform apply -target=module.cluster_init
 
 # Installing Cert-Manager and Rancher
 terraform apply -target=module.rancher_init
+
+# Create default node templates
+terraform apply -target=module.node_init
 ```
 
 ## Project Structure
 
-This Project consists of two modules.
+This Project consists of three modules.
 The `module-cluster-init` is for creating a basic RKE-Cluster on Hetzner Cloud, including server provisioning.
 The `module-rancher-init` is for installing Cert-Manager and Rancher on top of your provisioned cluster.
+The `module-node-init` creates Node Templates for Hetzner Cloud on your newly created Rancher instance.
 
 ### Why is this divided into modules?
 

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,3 @@
-terraform {
-  required_providers {
-    hcloud = {
-      source  = "hetznercloud/hcloud"
-      version = "1.23.0"
-    }
-    rke = {
-      source  = "rancher/rke"
-      version = "1.1.5"
-    }
-  }
-}
-
 module "cluster_init" {
   source = "./module-cluster-init"
   hcloud_token         = var.hcloud_token
@@ -32,4 +19,13 @@ module "rancher_init" {
   rancher_hostname       = var.rancher_hostname
   kubeconfig_path        = module.cluster_init.kubeconfig_path
   lb_address             = module.cluster_init.lb_address
+}
+
+module "node_init" {
+  source              = "./module-node-init"
+  rancher_admin_token = module.rancher_init.rancher_admin_token
+  hcloud_token        = var.hcloud_token
+  rancher_hostname    = var.rancher_hostname
+  lb_address          = module.cluster_init.lb_address
+  hetzner_driver_id   = module.rancher_init.hetzner_driver_id
 }

--- a/module-cluster-init/resources_rke.tf
+++ b/module-cluster-init/resources_rke.tf
@@ -12,7 +12,7 @@ resource "rke_cluster" "rancher_management_cluster" {
       role             = ["controlplane", "worker", "etcd"]
       user             = "root"
       ssh_agent_auth   = true
-      ssh_key          = file("~/.ssh/rancher_management")
+      ssh_key          = file(var.hcloud_ssh_key_path)
     }
   }
 

--- a/module-node-init/main.tf
+++ b/module-node-init/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     rancher2 = {
       source = "rancher/rancher2"
-      version = "1.10.7" # Need to change this version after feature gets released
+      version = "1.11.0"
     }
   }
 }

--- a/module-node-init/main.tf
+++ b/module-node-init/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    rancher2 = {
+      source = "rancher/rancher2"
+      version = "1.10.7" # Need to change this version after feature gets released
+    }
+  }
+}
+
+provider "rancher2" {
+  api_url   = var.rancher_hostname != null ? "https://${var.rancher_hostname}" : "https://rancher.${var.lb_address}.nip.io"
+  token_key = var.rancher_admin_token
+  insecure  = true
+}
+
+resource "rancher2_node_template" "hetzner_create_template" {
+  name        = "hetzner-default"
+  description = "Default template to acquire Hetzner Cloud Nodes"
+  driver_id   = var.hetzner_driver_id
+  hetzner_config {
+    api_token       = var.hcloud_token
+    image           = "ubuntu-20.04"
+    server_type     = "cx31"
+    server_location = "hel1"
+    networks        = "kubernetes-internal"
+  }
+}

--- a/module-node-init/variables.tf
+++ b/module-node-init/variables.tf
@@ -1,0 +1,19 @@
+variable "rancher_admin_token" {
+  type = string
+}
+
+variable "hcloud_token" {
+  type = string
+}
+
+variable "rancher_hostname" {
+  type = string
+}
+
+variable "lb_address" {
+  type = string
+}
+
+variable "hetzner_driver_id" {
+  type = string
+}

--- a/module-rancher-init/main.tf
+++ b/module-rancher-init/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     rancher2 = {
       source = "rancher/rancher2"
-      version = "1.10.6"
+      version = "1.10.6" # Need to change this version after feature gets released
     }
   }
 }
@@ -92,4 +92,12 @@ resource "rancher2_node_driver" "hetzner_node_driver" {
   ui_url   = "https://storage.googleapis.com/hcloud-rancher-v2-ui-driver/component.js"
   url      = "https://github.com/JonasProgrammer/docker-machine-driver-hetzner/releases/download/3.0.0/docker-machine-driver-hetzner_3.0.0_linux_amd64.tar.gz"
   whitelist_domains = ["storage.googleapis.com"]
+}
+
+output "rancher_admin_token" {
+  value = rancher2_bootstrap.setup_admin.token
+}
+
+output "hetzner_driver_id" {
+  value = rancher2_node_driver.hetzner_node_driver.id
 }

--- a/module-rancher-init/main.tf
+++ b/module-rancher-init/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     rancher2 = {
       source = "rancher/rancher2"
-      version = "1.10.6" # Need to change this version after feature gets released
+      version = "1.11.0"
     }
   }
 }


### PR DESCRIPTION
This MR adds a module to creates a Node Template for provisioning Clusters on Hetzner Cloud using nothing as just the Rancher-API.

It depends on https://github.com/rancher/terraform-provider-rancher2/pull/522

After this MR gets released, the version of the Rancher Provider must be updated.