### PR TITLE
Node template support, network support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,8 @@ module "cluster_init" {
   lb_name              = var.lb_name
   lb_type              = var.lb_type
   private_network_name = var.private_network_name
+  ip_range             = var.ip_range
+  subnet_ip_range      = var.subnet_ip_range
 }
 
 module "rancher_init" {
@@ -29,4 +31,8 @@ module "node_init" {
   lb_address           = module.cluster_init.lb_address
   hetzner_driver_id    = module.rancher_init.hetzner_driver_id
   private_network_name = var.private_network_name
+  use_private_networks = var.use_private_networks
+  userdata             = var.node_cloud_init_path
+  node_template_types  = var.node_template_types
+  node_template_zones  = var.node_template_zones
 }

--- a/module-cluster-init/resources_hetzner.tf
+++ b/module-cluster-init/resources_hetzner.tf
@@ -7,7 +7,7 @@ provider "hcloud" {
 
 resource "hcloud_network" "kubernetes_internal_network" {
   name     = var.private_network_name
-  ip_range = "172.16.0.0/12"
+  ip_range = var.ip_range
 
   labels = {
     automated = true
@@ -55,7 +55,7 @@ resource "hcloud_network_subnet" "rancher_management_subnet" {
   network_id   = hcloud_network.kubernetes_internal_network.id
   type         = "cloud"
   network_zone = "eu-central"
-  ip_range     = "172.16.1.0/24"
+  ip_range     = var.subnet_ip_range
 }
 
 resource "hcloud_server_network" "rancher_node_subnet_registration" {

--- a/module-cluster-init/variables.tf
+++ b/module-cluster-init/variables.tf
@@ -56,3 +56,15 @@ variable "private_network_name" {
     default = "kubernetes-internal"
     description = "Name of the private network that is created for your nodes. "
 }
+
+variable "ip_range" {
+    type = string
+    default = "172.16.0.0/12"
+    description = "Ip Range to use for setting up Hetzner network."
+}
+
+variable "subnet_ip_range" {
+    type = string
+    default = "172.16.1.0/24"
+    description = "Subnet Ip Range to use for setting up Hetzner network."
+}

--- a/module-node-init/main.tf
+++ b/module-node-init/main.tf
@@ -13,15 +13,69 @@ provider "rancher2" {
   insecure  = true
 }
 
-resource "rancher2_node_template" "hetzner_create_template" {
-  name        = "hetzner-default"
-  description = "Default template to acquire Hetzner Cloud Nodes"
+
+locals {
+
+  servers = {
+    "cx" = [
+      { "id" = "cx11", "name" = "1cpu_2gb_intel" },
+      { "id" = "cx21", "name" = "2cpu_4gb_intel" },
+      { "id" = "cx31", "name" = "2cpu_8gb_intel" },
+      { "id" = "cx41", "name" = "4cpu_16gb_intel" },
+      { "id" = "cx51", "name" = "8cpu_32gb_intel" }
+    ],
+    "cx-ceph" = [
+      { "id" = "cx11-ceph", "name" = "1cpu_2gb_intel" },
+      { "id" = "cx21-ceph", "name" = "2cpu_4gb_intel" },
+      { "id" = "cx31-ceph", "name" = "2cpu_8gb_intel" },
+      { "id" = "cx41-ceph", "name" = "4cpu_16gb_intel" },
+      { "id" = "cx51-ceph", "name" = "8cpu_32gb_intel" },      
+    ],
+    "cpx" = [
+      { "id" = "cpx11", "name" = "2cpu_2gb_amd" },
+      { "id" = "cpx21", "name" = "3cpu_4gb_amd" },
+      { "id" = "cpx31", "name" = "4cpu_8gb_amd" },
+      { "id" = "cpx41", "name" = "8cpu_16gb_amd" },
+      { "id" = "cpx51", "name" = "16cpu_32gb_amd" },      
+    ],
+    "ccx" = [
+      { "id" = "ccx11", "name" = "2cpu_8gb_dedi_intel" },
+      { "id" = "ccx21", "name" = "4cpu_16gb_dedi_intel" },
+      { "id" = "ccx31", "name" = "8cpu_32gb_dedi_intel" },
+      { "id" = "ccx41", "name" = "16cpu_64gb_dedi_intel" },
+      { "id" = "ccx51", "name" = "32cpu_128gb_dedi_intel" },      
+    ]
+  }
+
+  node_types = flatten([
+    for zone in var.node_template_zones : [
+      for type, def in local.servers :  [
+        for d in def : {
+          zone = zone
+          server = type
+          type  = d.id
+          description  = d.name
+        }
+      ]
+    ]
+  ])
+}
+
+resource "rancher2_node_template" "hetzner_nodes" {
+  for_each = {
+    for node in local.node_types : "${node.zone}.${node.type}" => node
+    if contains(var.node_template_types, node.server)
+  }
+
+  name        = "${each.value.zone}_${each.value.type}_${each.value.description}"
   driver_id   = var.hetzner_driver_id
   hetzner_config {
-    api_token       = var.hcloud_token
-    image           = "ubuntu-20.04"
-    server_type     = "cx31"
-    server_location = "hel1"
-    networks        = var.private_network_name
+    api_token            = var.hcloud_token
+    image                = "ubuntu-20.04"
+    server_type          = each.value.type
+    server_location      = each.value.zone
+    networks             = var.private_network_name
+    use_private_networks = var.use_private_networks
+    userdata             = file(var.userdata)
   }
 }

--- a/module-node-init/variables.tf
+++ b/module-node-init/variables.tf
@@ -18,6 +18,22 @@ variable "hetzner_driver_id" {
   type = string
 }
 
+variable "use_private_networks" {
+  type = bool
+}
+
 variable "private_network_name" {
-    type = string
+  type = string
+}
+
+variable "userdata" {
+  type = string
+}
+
+variable "node_template_types" {
+  type = list(string)
+}
+
+variable "node_template_zones" {
+  type = list(string)
 }

--- a/module-rancher-init/main.tf
+++ b/module-rancher-init/main.tf
@@ -78,14 +78,14 @@ resource "helm_release" "rancher" {
 }
 
 resource "rancher2_bootstrap" "setup_admin" {
-  provider   = "rancher2.bootstrap"
+  provider   = rancher2.bootstrap
   password   = var.rancher_admin_password
   telemetry  = true
   depends_on = [helm_release.rancher]
 }
 
 resource "rancher2_node_driver" "hetzner_node_driver" {
-  provider = "rancher2.admin"
+  provider = rancher2.admin
   active   = true
   builtin  = false
   name     = "Hetzner"

--- a/variables.tf
+++ b/variables.tf
@@ -72,3 +72,39 @@ variable "private_network_name" {
     default = "kubernetes-internal"
     description = "Name of the private network that is created for your nodes. "
 }
+
+variable "ip_range" {
+    type = string
+    default = "172.16.0.0/12"
+    description = "Ip Range to use for setting up Hetzner network."
+}
+
+variable "subnet_ip_range" {
+    type = string
+    default = "172.16.1.0/24"
+    description = "Subnet Ip Range to use for setting up Hetzner network."
+}
+
+variable "use_private_networks" {
+  type = bool
+  default = false
+  description = "Use private network in node templates."
+}
+
+variable "node_cloud_init_path" {
+    type = string
+    default = ""
+    description = "Path to the cloud init user data for node templates."
+}
+
+variable "node_template_types" {
+    type = list(string)
+    default = ["cx", "cx-ceph", "cpx", "ccx"]
+    description = "All server types for which a node template will be created"
+}
+
+variable "node_template_zones" {
+    type = list(string)
+    default = ["nbg1", "fsn1", "hel1"]
+    description = "All zones for which a node template will be created."
+}


### PR DESCRIPTION
This PR contains support for :

This allows you to set your ip range and subnet for private network:
https://github.com/alexzimmer96/rancher-hcloud/issues/2

```
variable "ip_range" {
    type = string
    default = "172.16.0.0/12"
    description = "Ip Range to use for setting up Hetzner network."
}

variable "subnet_ip_range" {
    type = string
    default = "172.16.1.0/24"
    description = "Subnet Ip Range to use for setting up Hetzner network."
}
```

Extra parameters for the node-init:
Solving https://github.com/alexzimmer96/rancher-hcloud/issues/10

```
variable "use_private_networks" {
  type = bool
  default = false
  description = "Use private network in node templates."
}

variable "node_cloud_init_path" {
    type = string
    default = ""
    description = "Path to the cloud init user data for node templates."
}

variable "node_template_types" {
    type = list(string)
    default = ["cx", "cx-ceph", "cpx", "ccx"]
    description = "All server types for which a node template will be created"
}

variable "node_template_zones" {
    type = list(string)
    default = ["nbg1", "fsn1", "hel1"]
    description = "All zones for which a node template will be created."
}
```

The node init will create by default ALL possible nodes, but with the above variables you can choose from zones and type combination.

Please note that https://github.com/alexzimmer96/rancher-hcloud/issues/11 private network checkbox is not working.
