### PR TITLE
Switched to rancher v2.5.9 from stable branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .terraform/
 
 .terraform.tfstate.lock.info
+.terraform.lock.hcl
 *.tfvars
 *.tfstate
 *.tfstate.backup

--- a/module-cluster-init/main.tf
+++ b/module-cluster-init/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "1.24.0"
+      version = "1.31.0"
     }
     rke = {
       source  = "rancher/rke"

--- a/module-cluster-init/resources_rke.tf
+++ b/module-cluster-init/resources_rke.tf
@@ -1,5 +1,3 @@
-provider "rke" {}
-
 resource "rke_cluster" "rancher_management_cluster" {
   cluster_name       = "rancher-management"
   kubernetes_version = "v1.19.6-rancher1-1"

--- a/module-node-init/main.tf
+++ b/module-node-init/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     rancher2 = {
       source = "rancher/rancher2"
-      version = "1.11.0"
+      version = "1.17.2"
     }
   }
 }

--- a/module-rancher-init/main.tf
+++ b/module-rancher-init/main.tf
@@ -53,7 +53,8 @@ resource "helm_release" "rancher" {
   name = "rancher"
   namespace = "cattle-system"
   chart = "rancher"
-  repository = "https://releases.rancher.com/server-charts/latest"
+  version = "2.5.9"
+  repository = "https://releases.rancher.com/server-charts/stable"
   depends_on = [helm_release.cert_manager]
 
   wait             = true

--- a/module-rancher-init/main.tf
+++ b/module-rancher-init/main.tf
@@ -78,14 +78,14 @@ resource "helm_release" "rancher" {
 }
 
 resource "rancher2_bootstrap" "setup_admin" {
-  provider   = "rancher2.bootstrap"
+  provider   = rancher2.bootstrap
   password   = var.rancher_admin_password
   telemetry  = true
   depends_on = [helm_release.rancher]
 }
 
 resource "rancher2_node_driver" "hetzner_node_driver" {
-  provider = "rancher2.admin"
+  provider = rancher2.admin
   active   = true
   builtin  = false
   name     = "Hetzner"

--- a/module-rancher-init/main.tf
+++ b/module-rancher-init/main.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "1.3.2"
+      version = "2.3.0"
     }
     rancher2 = {
       source = "rancher/rancher2"
-      version = "1.11.0"
+      version = "1.17.2"
     }
   }
 }
@@ -36,7 +36,7 @@ resource "helm_release" "cert_manager" {
   namespace        = "cert-manager"
   repository       = "https://charts.jetstack.io"
   chart            = "cert-manager"
-  version          = "1.0.4"
+  version          = "1.5.3"
 
   wait             = true
   create_namespace = true


### PR DESCRIPTION
fixes #14 
fixes #15 
fixes #17

There are some issues with rancher v2.6.0 and  terraform provider. 
Installing latest stable version 2.5.9 fixes the problem.

* Updated terraform providers
* Updated cert-manager version
* removed some warnings, but produced a new one, for which I didn't find a solution.

IMPORTANT: updating the environment by using ` terraform delete -target=module.rancher_init` and reapply causes the same error. Needed a whole cleanup `terraform delete`.  