### PR TITLE
Kubernetes v1.21.7, Rancher v2.6.3, Rancher RKE v1.3.0, setting bootstrapPassword

### DIFF
--- a/module-cluster-init/main.tf
+++ b/module-cluster-init/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     rke = {
       source  = "rancher/rke"
-      version = "1.1.7"
+      version = "1.3.0"
     }
   }
 }

--- a/module-cluster-init/resources_rke.tf
+++ b/module-cluster-init/resources_rke.tf
@@ -1,6 +1,6 @@
 resource "rke_cluster" "rancher_management_cluster" {
   cluster_name       = "rancher-management"
-  kubernetes_version = "v1.19.6-rancher1-1"
+  kubernetes_version = "v1.21.7-rancher1-1"
 
   dynamic "nodes" {
     for_each = hcloud_server.rancher_management_nodes

--- a/module-rancher-init/main.tf
+++ b/module-rancher-init/main.tf
@@ -53,7 +53,7 @@ resource "helm_release" "rancher" {
   name = "rancher"
   namespace = "cattle-system"
   chart = "rancher"
-  version = "2.5.9"
+  version = "2.6.3"
   repository = "https://releases.rancher.com/server-charts/stable"
   depends_on = [helm_release.cert_manager]
 
@@ -65,6 +65,11 @@ resource "helm_release" "rancher" {
   set {
     name  = "hostname"
     value = var.rancher_hostname != null ? var.rancher_hostname : "rancher.${var.lb_address}.nip.io"
+  }
+
+  set {
+    name  = "bootstrapPassword"
+    value = var.rancher_admin_password
   }
 
   set {
@@ -81,6 +86,7 @@ resource "helm_release" "rancher" {
 resource "rancher2_bootstrap" "setup_admin" {
   provider   = rancher2.bootstrap
   password   = var.rancher_admin_password
+  current_password   = var.rancher_admin_password
   telemetry  = true
   depends_on = [helm_release.rancher]
 }


### PR DESCRIPTION
This PR updates Kubernetes to 1.21.7, Rancher to 2.6.3 and fixes the bootstrapPassword/login authentification error when applying module.rancher_init.